### PR TITLE
[FIX] Use orgtbl-mode instead of org-mode

### DIFF
--- a/syncthing-draw.el
+++ b/syncthing-draw.el
@@ -166,7 +166,7 @@
                         (iso8601-parse (alist-get 'time item)))))
                      text)))
            (insert (string-join (reverse text) "\n")))
-         (org-mode)
+         (orgtbl-mode)
          (org-table-align)
          (substring-no-properties (buffer-string)))))))
 


### PR DESCRIPTION
Invoking org-mode runs a bunch of org-mode hooks and is overkill for formatting a single table. Instead, this patch enables the orgtbl minor mode, a mode specifically designed for this use-case.