### PR TITLE
[ADD] Auto-refresh buffer only when visible

### DIFF
--- a/syncthing.el
+++ b/syncthing.el
@@ -111,7 +111,10 @@ Activating this mode will launch Syncthing client in the current window.
     (user-error "Buffer not in `syncthing-mode'"))
   (setq-local
    buffer-stale-function
-   (when syncthing-auto-refresh-mode (lambda (&rest _) t))
+   (when syncthing-auto-refresh-mode
+     (lambda (&rest _)
+       (or (zerop (buffer-size))               ; Initial update.
+           (get-buffer-window nil 'visible)))) ; Or if the buffer is visible.
    auto-revert-interval
    (when syncthing-auto-refresh-mode syncthing-auto-refresh-interval))
   (when syncthing-no-upstream-noise


### PR DESCRIPTION
This modifies the auto-refresh mode to only update the buffer when it's
visible. This makes it possible to quit/burry the syncthing buffer and
avoid using resources in the background to constantly update the buffer.