### PR TITLE
[FIX] Switch a few icons and fix the associated documentation

### DIFF
--- a/syncthing-themes.el
+++ b/syncthing-themes.el
@@ -46,8 +46,8 @@
             :qr ""
             :tag ""
             :laptop ""
-            :envelope "✉"
-            :hourglass "⌛"
+            :envelope ""
+            :hourglass ""
             :info ""
             :folder-open ""
             :world ""
@@ -56,14 +56,14 @@
             :eye ""
             :lift ""
             :share ""
-            :swap "⇄"
+            :swap ""
             :cloud ""
             :link ""
             :signal ""
             :switch ""
             :press "")
     :text ,syncthing-theme--default-ascii)
-  "Default theme, working with DejaVu Sans Mono.")
+  "Default theme, working with Font Awesome and/or Nerd Fonts.")
 
 (defconst syncthing-theme-emoji-one
   `(:icons (:download "⬇️"


### PR DESCRIPTION
By and large, these icons actually come from Font Awesome, not DejaVu (they're also available in any Nerd Font). However, a few icons didn't come from Font Awesome and looked out of place so I replaced them with their Font Awesome variants.